### PR TITLE
fix(api): 🐛 correct API endpoint path for user fetch

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -27,7 +27,7 @@ const { ...attrs } = Astro.props as Props;
 let isLoggedIn = false;
 
 try {
-	const response = await fetch(`${Astro.url.origin}/api/user`, {
+	const response = await fetch("/api/user", {
 		headers: {
 			cookie: Astro.request.headers.get("cookie") || "",
 		},

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -163,18 +163,34 @@ const authInfo: AuthInfo = {
       try {
         const response = await fetch('/api/user');
         const data = await response.json<{ isLoggedIn: boolean }>();
+
+        // Get current language
+        const currentLang = document.documentElement.lang || 'en';
+
+        // Simple client-side path translation function
+        const translatePath = (path: string) => {
+          // Default language (en) doesn't need prefix
+          if (currentLang === 'en') return path;
+          // Other languages need prefix
+          return `/${currentLang}${path}`;
+        };
+
         // Update the auth button if needed
         if (data.isLoggedIn) {
-          const authLink = document.querySelector('a[href="/signin"]');
-          if (authLink) {
-            authLink.setAttribute('href', '/account');
-            const textSpan = authLink.querySelector('span');
+          // Use a more robust selector that can find links with or without language prefix
+          const signinPath = translatePath('/signin');
+          const accountPath = translatePath('/account');
+
+          // Find auth links - both with and without language prefix
+          const authLinks = document.querySelectorAll(`a[href="${signinPath}"], a[href="/signin"]`);
+
+          authLinks.forEach(link => {
+            link.setAttribute('href', accountPath);
+            const textSpan = link.querySelector('span');
             if (textSpan) {
-              // Translate based on current language
-              const currentLang = document.documentElement.lang || 'en';
               textSpan.textContent = currentLang === 'es' ? 'Cuenta' : 'Account';
             }
-          }
+          });
         }
       } catch (error) {
         console.error("Error checking user status:", error);


### PR DESCRIPTION
Fix endpoint path for user fetch in the header
This pull request includes a change to the `src/components/Header.astro` file to simplify the URL used in an API call.

* [`src/components/Header.astro`](diffhunk://#diff-cef92c86af879f90a7ac8087da782381ed31160251d9960fe59f7ee29389a9beL30-R30): Modified the fetch URL in the API call to use a relative path instead of `${Astro.url.origin}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a client-side function for dynamic URL translations based on the current language.
  - Enhanced logic for updating authentication links to support language-prefixed and non-prefixed paths.
- **Refactor**
  - Updated the user data retrieval process to use a simpler relative API endpoint, ensuring smoother behavior across different deployment scenarios without altering the existing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->