### PR TITLE
chore(gitignore): ✨ add .playwright-mcp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ Icon
 coverage*
 coverage/
 **/coverage/
+
+# MCPs
+.playwright-mcp

--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -3,7 +3,7 @@ import mdx from "@astrojs/mdx";
 import partytown from "@astrojs/partytown";
 import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig, envField, passthroughImageService } from "astro/config";
+import { defineConfig, envField } from "astro/config";
 import icon from "astro-icon";
 import pagefind from "astro-pagefind";
 import { BASE_URL } from "./src/consts.ts";
@@ -47,7 +47,6 @@ export default defineConfig({
 	},
 
 	image: {
-		service: passthroughImageService(),
 		remotePatterns: [
 			{
 				protocol: "https",


### PR DESCRIPTION
This pull request makes a minor configuration update to the Astro website project. The main change is the removal of the `passthroughImageService` from the image service configuration in `astro.config.mjs`, simplifying the image handling setup.

Configuration update:

* Removed the use of `passthroughImageService` from the `image.service` configuration in `astro.config.mjs`.
* Cleaned up the import statements by removing the unused `passthroughImageService` import.